### PR TITLE
Fix squashfuse_ll readlink one symbol less from a symlink

### DIFF
--- a/fs.c
+++ b/fs.c
@@ -283,7 +283,7 @@ sqfs_err sqfs_readlink(sqfs *fs, sqfs_inode *inode, char *buf, size_t *size) {
 
 	want = inode->xtra.symlink_size;
 	if (!buf) {
-		*size = want;
+		*size = want + 1;
 		return SQFS_OK;
 	}
 


### PR DESCRIPTION
Test plan:

$ ln -s 123456789 link
$ mksquashfs link image.sqfs
$ mkdir dest
$ squashfuse_ll -d -f image.sqfs dest
$ readlink dest/link
123456789
